### PR TITLE
SMAF Engine Enhancement

### DIFF
--- a/smaf/src/chunks.rs
+++ b/smaf/src/chunks.rs
@@ -21,7 +21,14 @@ pub fn parse_timebase(raw: u8) -> u8 {
 
 pub fn parse_variable_number(input: &[u8]) -> IResult<&[u8], u32> {
     let mut data = input;
-    let mut result = 0;
+    let (remaining, first) = u8(data)?;
+    data = remaining;
+
+    if first & 0b1000_0000 == 0 {
+        return Ok((data, (first & 0b0111_1111) as u32));
+    }
+
+    let mut result = (first & 0b0111_1111) as u32;
     loop {
         let (remaining, byte) = u8(data)?;
         data = remaining;
@@ -34,9 +41,20 @@ pub fn parse_variable_number(input: &[u8]) -> IResult<&[u8], u32> {
     Ok((data, result))
 }
 
+pub fn parse_handy_variable_number(input: &[u8]) -> IResult<&[u8], u32> {
+    let (remaining, first) = u8(input)?;
+    if first & 0b1000_0000 == 0 {
+        return Ok((remaining, first as u32));
+    }
+
+    let (remaining, second) = u8(remaining)?;
+    let result = ((((first & 0b0111_1111) as u32) + 1) << 7) | (second as u32);
+    Ok((remaining, result))
+}
+
 pub use self::{
     content_info::ContentsInfoChunk,
     optional_data::OptionalDataChunk,
     pcm_audio_track::{PCMAudioSequenceData, PCMAudioSequenceEvent, PCMAudioTrack, PCMAudioTrackChunk},
-    score_track::{PCMDataChunk, ScoreTrack, ScoreTrackChunk, ScoreTrackSequenceEvent, SequenceData, WaveData},
+    score_track::{ChannelStatus, ChannelType, PCMDataChunk, ScoreTrack, ScoreTrackChunk, ScoreTrackSequenceEvent, SequenceData, WaveData},
 };

--- a/smaf/src/chunks/pcm_audio_track.rs
+++ b/smaf/src/chunks/pcm_audio_track.rs
@@ -14,6 +14,9 @@ use crate::{
     constants::{BaseBit, Channel, PcmWaveFormat},
 };
 
+const SHORT_PITCH_BEND_VALUES: [u8; 15] = [0x00, 0x08, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38, 0x40, 0x48, 0x50, 0x58, 0x60, 0x68, 0x70];
+const SHORT_EXPRESSION_VALUES: [u8; 15] = [0x00, 0x00, 0x1f, 0x27, 0x2f, 0x37, 0x3f, 0x47, 0x4f, 0x57, 0x5f, 0x67, 0x6f, 0x77, 0x7f];
+
 pub enum PCMAudioSequenceEvent {
     WaveMessage { channel: u8, wave_number: u8, gate_time: u32 },
     PitchBend { channel: u8, value: u8 },
@@ -90,7 +93,29 @@ impl PCMAudioSequenceData {
             } else {
                 let (remaining, second_byte) = u8(data)?;
                 let channel = (second_byte & 0b1100_0000) >> 6;
-                if second_byte & 0b0011_1100 == 0b0011_0100 {
+                let event_type = second_byte & 0b0011_1111;
+
+                if (0x01..=0x0e).contains(&event_type) {
+                    data = remaining;
+
+                    result.push(Self {
+                        duration,
+                        event: PCMAudioSequenceEvent::Expression {
+                            channel,
+                            value: SHORT_EXPRESSION_VALUES[event_type as usize],
+                        },
+                    })
+                } else if (0x11..=0x1e).contains(&event_type) {
+                    data = remaining;
+
+                    result.push(Self {
+                        duration,
+                        event: PCMAudioSequenceEvent::PitchBend {
+                            channel,
+                            value: SHORT_PITCH_BEND_VALUES[(event_type - 0x10) as usize],
+                        },
+                    })
+                } else if event_type == 0x34 {
                     let (remaining, value) = u8(remaining)?;
                     data = remaining;
 
@@ -98,16 +123,15 @@ impl PCMAudioSequenceData {
                         duration,
                         event: PCMAudioSequenceEvent::PitchBend { channel, value },
                     })
-                } else if second_byte & 0b0011_0000 == 0b0011_0000 {
+                } else if event_type == 0x36 || event_type == 0x3b {
+                    let (remaining, value) = u8(remaining)?;
                     data = remaining;
-
-                    let value = (second_byte & 0b0000_1111) * 8;
 
                     result.push(Self {
                         duration,
-                        event: PCMAudioSequenceEvent::PitchBend { channel, value },
+                        event: PCMAudioSequenceEvent::Expression { channel, value },
                     })
-                } else if second_byte & 0b0011_0111 == 0b0011_0110 {
+                } else if event_type == 0x37 {
                     let (remaining, value) = u8(remaining)?;
                     data = remaining;
 
@@ -115,7 +139,7 @@ impl PCMAudioSequenceData {
                         duration,
                         event: PCMAudioSequenceEvent::Volume { channel, value },
                     })
-                } else if second_byte & 0b0011_1010 == 0b0011_1010 {
+                } else if event_type == 0x3a {
                     let (remaining, value) = u8(remaining)?;
                     data = remaining;
 
@@ -123,22 +147,12 @@ impl PCMAudioSequenceData {
                         duration,
                         event: PCMAudioSequenceEvent::Pan { channel, value },
                     })
-                } else if second_byte & 0b0011_1011 == 0b0011_1011 {
-                    let (remaining, value) = u8(remaining)?;
+                } else if event_type == 0x00 {
                     data = remaining;
 
                     result.push(Self {
                         duration,
-                        event: PCMAudioSequenceEvent::Expression { channel, value },
-                    })
-                } else if second_byte & 0b0011_0000 == 0b0000_0000 {
-                    data = remaining;
-
-                    let value = ((second_byte & 0b0000_1111) - 1) * 31;
-
-                    result.push(Self {
-                        duration,
-                        event: PCMAudioSequenceEvent::Expression { channel, value },
+                        event: PCMAudioSequenceEvent::Nop,
                     })
                 } else {
                     panic!("Invalid second byte")
@@ -155,6 +169,7 @@ pub enum PCMAudioTrackChunk<'a> {
     SetupData(&'a [u8]),
     SequenceData(Vec<PCMAudioSequenceData>),
     WaveData(u8, &'a [u8]),
+    Unknown(&'a [u8], &'a [u8]),
 }
 
 impl<'a> Parse<&'a [u8]> for PCMAudioTrackChunk<'a> {
@@ -165,12 +180,7 @@ impl<'a> Parse<&'a [u8]> for PCMAudioTrackChunk<'a> {
                 b"Atsu" => PCMAudioTrackChunk::SetupData(data),
                 b"Atsq" => PCMAudioTrackChunk::SequenceData(all_consuming(PCMAudioSequenceData::parse)(data)?.1),
                 &[b'A', b'w', b'a', x] => PCMAudioTrackChunk::WaveData(x, data),
-                _ => {
-                    return Err(nom::Err::Error::<nom::error::Error<&'a [u8]>>(nom::error_position!(
-                        data,
-                        nom::error::ErrorKind::Switch
-                    )))
-                }
+                _ => PCMAudioTrackChunk::Unknown(tag, data),
             })
         })(data)
     }

--- a/smaf/src/chunks/score_track.rs
+++ b/smaf/src/chunks/score_track.rs
@@ -11,9 +11,12 @@ use nom::{
 use nom_derive::{NomBE, Parse};
 
 use crate::{
-    chunks::{parse_timebase, parse_variable_number},
+    chunks::{parse_handy_variable_number, parse_timebase, parse_variable_number},
     constants::{BaseBit, Channel, FormatType, StreamWaveFormat},
 };
+
+const SHORT_MOD_VALUES: [u8; 15] = [0x00, 0x00, 0x08, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38, 0x40, 0x48, 0x50, 0x60, 0x70, 0x7f];
+const SHORT_EXPRESSION_VALUES: [u8; 15] = [0x00, 0x00, 0x1f, 0x27, 0x2f, 0x37, 0x3f, 0x47, 0x4f, 0x57, 0x5f, 0x67, 0x6f, 0x77, 0x7f];
 
 pub struct WaveData<'a> {
     pub channel: Channel,
@@ -57,16 +60,49 @@ impl<'a> Parse<&'a [u8]> for PCMDataChunk<'a> {
 }
 
 pub enum ScoreTrackSequenceEvent {
-    NoteMessage { channel: u8, note: u8, velocity: u8, gate_time: u32 },
-    ControlChange { channel: u8, control: u8, value: u8 },
-    ProgramChange { channel: u8, program: u8 },
-    BankSelect { channel: u8, value: u8 },
-    OctaveShift { channel: u8, value: u8 },
-    Modulation { channel: u8, value: u8 },
-    PitchBend { channel: u8, value: u16 },
-    Volume { channel: u8, value: u8 },
-    Pan { channel: u8, value: u8 },
-    Expression { channel: u8, value: u8 },
+    NoteMessage {
+        channel: u8,
+        note: u8,
+        velocity: Option<u8>,
+        gate_time: u32,
+    },
+    ControlChange {
+        channel: u8,
+        control: u8,
+        value: u8,
+    },
+    ProgramChange {
+        channel: u8,
+        program: u8,
+    },
+    BankSelect {
+        channel: u8,
+        value: u8,
+    },
+    OctaveShift {
+        channel: u8,
+        value: u8,
+    },
+    Modulation {
+        channel: u8,
+        value: u8,
+    },
+    PitchBend {
+        channel: u8,
+        value: u16,
+    },
+    Volume {
+        channel: u8,
+        value: u8,
+    },
+    Pan {
+        channel: u8,
+        value: u8,
+    },
+    Expression {
+        channel: u8,
+        value: u8,
+    },
     Exclusive(Vec<u8>),
     Nop,
 }
@@ -95,7 +131,7 @@ impl SequenceData {
                     ScoreTrackSequenceEvent::NoteMessage {
                         channel,
                         note,
-                        velocity: 64,
+                        velocity: None,
                         gate_time,
                     }
                 }
@@ -110,9 +146,15 @@ impl SequenceData {
                     ScoreTrackSequenceEvent::NoteMessage {
                         channel,
                         note,
-                        velocity,
+                        velocity: Some(velocity),
                         gate_time,
                     }
+                }
+                0xA0..=0xAF => {
+                    let (remaining, _) = take(2usize)(remaining)?;
+                    data = remaining;
+
+                    ScoreTrackSequenceEvent::Nop
                 }
                 0xB0..=0xBF => {
                     // ControlChange
@@ -130,6 +172,12 @@ impl SequenceData {
                     data = remaining;
 
                     ScoreTrackSequenceEvent::ProgramChange { channel, program }
+                }
+                0xD0..=0xDF => {
+                    let (remaining, _) = u8(remaining)?;
+                    data = remaining;
+
+                    ScoreTrackSequenceEvent::Nop
                 }
                 0xE0..=0xEF => {
                     // PitchBend (14-bit value: MSB << 7 | LSB)
@@ -167,13 +215,11 @@ impl SequenceData {
                         });
 
                         break;
-                    } else if second_byte == 0x00 {
-                        ScoreTrackSequenceEvent::Nop
                     } else {
-                        panic!("Invalid status byte");
+                        ScoreTrackSequenceEvent::Nop
                     }
                 }
-                _ => panic!("Invalid status byte {}", status_byte),
+                _ => ScoreTrackSequenceEvent::Nop,
             };
 
             result.push(Self { duration, event })
@@ -183,39 +229,45 @@ impl SequenceData {
     }
 
     pub fn parse_handy(input: &[u8]) -> IResult<&[u8], Vec<Self>> {
+        Self::parse_handy_like(input, false)
+    }
+
+    pub fn parse_softbank(input: &[u8]) -> IResult<&[u8], Vec<Self>> {
+        Self::parse_handy_like(input, true)
+    }
+
+    fn parse_handy_like(input: &[u8], softbank: bool) -> IResult<&[u8], Vec<Self>> {
         let mut data = input;
         let mut result = Vec::new();
         loop {
             if data.is_empty() {
                 break;
             }
-            if data[0] == 0 && data[1] == 0 && data[2] == 0 && data[3] == 0 {
+            if data.len() >= 4 && data[0] == 0 && data[1] == 0 && data[2] == 0 && data[3] == 0 {
                 // end of stream
                 data = &data[4..];
                 break;
             }
 
-            let (remaining, duration) = parse_variable_number(data)?;
+            let (remaining, duration) = parse_handy_variable_number(data)?;
             let (remaining, status_byte) = u8(remaining)?;
 
             let event = match status_byte {
                 0x01..=0xFE => {
                     // note
                     // Voice: 0x1=C#, 0x2=D, ..., 0x9=A, 0xA=A#, 0xB=B, 0xC=C
-                    // Octave 2 (Mid High), Voice 9 (A) = MIDI 69 (A440)
-                    // So base offset = 69 - 9 - 2*12 = 36
-                    let channel = (status_byte & 0b11000000) >> 6;
-                    let octave = (status_byte & 0b00110000) >> 4;
-                    let voice = status_byte & 0b00001111;
-                    let note_number = 36 + octave * 12 + voice;
+                    let channel = (status_byte & 0b1100_0000) >> 6;
+                    let octave = (status_byte & 0b0011_0000) >> 4;
+                    let voice = status_byte & 0b0000_1111;
+                    let note_number = octave * 12 + voice;
 
-                    let (remaining, gate_time) = parse_variable_number(remaining)?;
+                    let (remaining, gate_time) = parse_handy_variable_number(remaining)?;
                     data = remaining;
 
                     ScoreTrackSequenceEvent::NoteMessage {
                         channel,
                         note: note_number,
-                        velocity: 64,
+                        velocity: None,
                         gate_time,
                     }
                 }
@@ -223,104 +275,71 @@ impl SequenceData {
                     let (remaining, next_byte) = u8(remaining)?;
                     data = remaining;
 
-                    if next_byte & 0b00111111 == 0b00110000 {
-                        // program change
+                    let channel = (next_byte & 0b1100_0000) >> 6;
+                    let event_type = next_byte & 0b0011_1111;
 
-                        let (remaining, value) = u8(remaining)?;
+                    if event_type == 0x00 {
+                        let (remaining, _) = u8(remaining)?;
                         data = remaining;
-
-                        ScoreTrackSequenceEvent::ProgramChange {
-                            channel: (next_byte & 0b11000000) >> 6,
-                            program: value,
+                        ScoreTrackSequenceEvent::Nop
+                    } else if (0x01..=0x0e).contains(&event_type) {
+                        ScoreTrackSequenceEvent::Expression {
+                            channel,
+                            value: SHORT_EXPRESSION_VALUES[event_type as usize],
                         }
-                    } else if next_byte & 0b00111111 == 0b00110001 {
-                        // bank select
-
-                        let (remaining, value) = u8(remaining)?;
-                        data = remaining;
-
-                        ScoreTrackSequenceEvent::BankSelect {
-                            channel: (next_byte & 0b11000000) >> 6,
-                            value,
+                    } else if (0x11..=0x1e).contains(&event_type) {
+                        ScoreTrackSequenceEvent::PitchBend {
+                            channel,
+                            value: ((event_type as u16 - 0x10) * 16384 / 16).min(0x3fff),
                         }
-                    } else if next_byte & 0b00111111 == 0b00110010 {
-                        // octave shift
-
-                        let (remaining, value) = u8(remaining)?;
-                        data = remaining;
-
-                        ScoreTrackSequenceEvent::OctaveShift {
-                            channel: (next_byte & 0b11000000) >> 6,
-                            value,
-                        }
-                    } else if next_byte & 0b00111111 == 0b00110011 {
-                        // modulation
-
-                        let (remaining, value) = u8(remaining)?;
-                        data = remaining;
-
+                    } else if (0x21..=0x2e).contains(&event_type) {
                         ScoreTrackSequenceEvent::Modulation {
-                            channel: (next_byte & 0b11000000) >> 6,
-                            value,
+                            channel,
+                            value: SHORT_MOD_VALUES[(event_type - 0x20) as usize],
                         }
-                    } else if next_byte & 0b00111111 == 0b00111000 {
-                        // pitch bend
+                    } else if event_type == 0x30 {
+                        let (remaining, value) = u8(remaining)?;
+                        data = remaining;
 
+                        ScoreTrackSequenceEvent::ProgramChange { channel, program: value }
+                    } else if event_type == 0x31 {
+                        let (remaining, value) = u8(remaining)?;
+                        data = remaining;
+
+                        ScoreTrackSequenceEvent::BankSelect { channel, value }
+                    } else if event_type == 0x32 {
+                        let (remaining, value) = u8(remaining)?;
+                        data = remaining;
+
+                        ScoreTrackSequenceEvent::OctaveShift { channel, value }
+                    } else if event_type == 0x33 {
+                        let (remaining, value) = u8(remaining)?;
+                        data = remaining;
+
+                        ScoreTrackSequenceEvent::Modulation { channel, value }
+                    } else if event_type == 0x34 {
                         let (remaining, value) = u8(remaining)?;
                         data = remaining;
 
                         ScoreTrackSequenceEvent::PitchBend {
-                            channel: (next_byte & 0b11000000) >> 6,
-                            value: value as _,
+                            channel,
+                            value: pitch_bend_byte_to_midi(value),
                         }
-                    } else if next_byte & 0b00110000 == 0b00010000 {
-                        // pitch bend short
-
-                        let value = next_byte & 0b00001111;
-
-                        ScoreTrackSequenceEvent::PitchBend {
-                            channel: (next_byte & 0b11000000) >> 6,
-                            value: value as _,
-                        }
-                    } else if next_byte & 0b00111111 == 0b00110111 {
-                        // volume
-
+                    } else if event_type == 0x36 || event_type == 0x3b {
                         let (remaining, value) = u8(remaining)?;
                         data = remaining;
 
-                        ScoreTrackSequenceEvent::Volume {
-                            channel: (next_byte & 0b11000000) >> 6,
-                            value,
-                        }
-                    } else if next_byte & 0b00111111 == 0b00111010 {
-                        // pan
-
+                        ScoreTrackSequenceEvent::Expression { channel, value }
+                    } else if event_type == 0x37 {
                         let (remaining, value) = u8(remaining)?;
                         data = remaining;
 
-                        ScoreTrackSequenceEvent::Pan {
-                            channel: (next_byte & 0b11000000) >> 6,
-                            value,
-                        }
-                    } else if next_byte & 0b00111111 == 0b00111011 {
-                        // expression
-
+                        ScoreTrackSequenceEvent::Volume { channel, value }
+                    } else if event_type == 0x3a {
                         let (remaining, value) = u8(remaining)?;
                         data = remaining;
 
-                        ScoreTrackSequenceEvent::Expression {
-                            channel: (next_byte & 0b11000000) >> 6,
-                            value,
-                        }
-                    } else if next_byte & 0b00110000 == 0b0000_0000 {
-                        // expression short
-
-                        let value = next_byte & 0b00001111;
-
-                        ScoreTrackSequenceEvent::Expression {
-                            channel: (next_byte & 0b11000000) >> 6,
-                            value,
-                        }
+                        ScoreTrackSequenceEvent::Pan { channel, value }
                     } else {
                         // TODO Invalid status byte warning
 
@@ -333,11 +352,23 @@ impl SequenceData {
 
                     if next_byte == 0b1111_0000 {
                         // exclusive message
-                        let (remaining, length) = u8(remaining)?;
-                        let (remaining, exclusive_data) = take(length)(remaining)?;
-                        data = remaining;
+                        if softbank {
+                            let (remaining, length) = u8(remaining)?;
+                            let (remaining, exclusive_data) = take(length)(remaining)?;
+                            data = remaining;
 
-                        ScoreTrackSequenceEvent::Exclusive(exclusive_data.to_vec())
+                            ScoreTrackSequenceEvent::Exclusive(exclusive_data.to_vec())
+                        } else {
+                            let end = remaining.iter().position(|&x| x == 0xf7).unwrap_or(remaining.len());
+                            let exclusive_data = remaining[..end].to_vec();
+                            data = if end < remaining.len() {
+                                &remaining[end + 1..]
+                            } else {
+                                &remaining[end..]
+                            };
+
+                            ScoreTrackSequenceEvent::Exclusive(exclusive_data)
+                        }
                     } else if next_byte == 0 {
                         // nop
 
@@ -355,12 +386,107 @@ impl SequenceData {
     }
 }
 
+#[allow(clippy::let_and_return)]
+fn parse_mobile_compressed(data: &[u8]) -> IResult<&[u8], Vec<SequenceData>> {
+    let (remaining, decoded_len) = be_u32(data)?;
+    let decoded =
+        huffman_decode(decoded_len as usize, remaining).ok_or_else(|| nom::Err::Error(nom::error_position!(data, nom::error::ErrorKind::Verify)))?;
+    let empty: &[u8] = &[];
+    let parsed = match all_consuming(SequenceData::parse_mobile)(&decoded) {
+        Ok((_, events)) => Ok((empty, events)),
+        Err(_) => Err(nom::Err::Error(nom::error_position!(data, nom::error::ErrorKind::Verify))),
+    };
+    parsed
+}
+
+fn huffman_decode(decoded_len: usize, src: &[u8]) -> Option<Vec<u8>> {
+    const N: usize = 256;
+
+    struct BitReader<'a> {
+        data: &'a [u8],
+        byte_offset: usize,
+        bit_offset: u8,
+    }
+
+    impl<'a> BitReader<'a> {
+        fn new(data: &'a [u8]) -> Self {
+            Self {
+                data,
+                byte_offset: 0,
+                bit_offset: 8,
+            }
+        }
+
+        fn bit_read(&mut self) -> Option<u8> {
+            if self.bit_offset == 8 {
+                if self.byte_offset >= self.data.len() {
+                    return None;
+                }
+                self.bit_offset = 0;
+            }
+
+            let bit = (self.data[self.byte_offset] >> (7 - self.bit_offset)) & 1;
+            self.bit_offset += 1;
+            if self.bit_offset == 8 {
+                self.byte_offset += 1;
+            }
+            Some(bit)
+        }
+
+        fn bit_n_read(&mut self, n: u8) -> Option<usize> {
+            let mut bits = 0usize;
+            for _ in 0..n {
+                bits = (bits << 1) | (self.bit_read()? as usize);
+            }
+            Some(bits)
+        }
+    }
+
+    fn read_tree(reader: &mut BitReader<'_>, left: &mut [usize], right: &mut [usize], avail: &mut usize) -> Option<usize> {
+        if reader.bit_read()? == 1 {
+            let node = *avail;
+            *avail += 1;
+            if *avail > 2 * N - 1 {
+                return None;
+            }
+            left[node] = read_tree(reader, left, right, avail)?;
+            right[node] = read_tree(reader, left, right, avail)?;
+            Some(node)
+        } else {
+            reader.bit_n_read(8)
+        }
+    }
+
+    let mut left = [0usize; 2 * N - 1];
+    let mut right = [0usize; 2 * N - 1];
+    let mut avail = N;
+    let mut reader = BitReader::new(src);
+    let root = read_tree(&mut reader, &mut left, &mut right, &mut avail)?;
+
+    let mut decoded = Vec::with_capacity(decoded_len);
+    for _ in 0..decoded_len {
+        let mut node = root;
+        while node >= N {
+            node = if reader.bit_read()? == 1 { right[node] } else { left[node] };
+        }
+        decoded.push(node as u8);
+    }
+
+    Some(decoded)
+}
+
+fn pitch_bend_byte_to_midi(value: u8) -> u16 {
+    let offset = ((value as i32) - 128) * 64;
+    (8192 + offset).clamp(0, 16383) as u16
+}
+
 #[allow(clippy::enum_variant_names)]
 pub enum ScoreTrackChunk<'a> {
     SetupData(&'a [u8]),
     SequenceData(Vec<SequenceData>),
     PCMData(Vec<PCMDataChunk<'a>>),
     SeekAndPhraseInfo(&'a [u8]),
+    Unknown(&'a [u8], &'a [u8]),
 }
 
 impl<'a> ScoreTrackChunk<'a> {
@@ -371,14 +497,15 @@ impl<'a> ScoreTrackChunk<'a> {
                 b"Mtsq" => {
                     let parser = match format_type {
                         FormatType::MobileStandardNoCompress => SequenceData::parse_mobile,
+                        FormatType::MobileStandardCompress => parse_mobile_compressed,
                         FormatType::HandyPhoneStandard => SequenceData::parse_handy,
-                        _ => panic!("Unsupported format type {:?}", format_type),
                     };
                     ScoreTrackChunk::SequenceData(all_consuming(parser)(data)?.1)
                 }
+                b"SEQU" => ScoreTrackChunk::SequenceData(all_consuming(SequenceData::parse_softbank)(data)?.1),
                 b"Mtsp" => ScoreTrackChunk::PCMData(all_consuming(many0(complete(PCMDataChunk::parse)))(data)?.1),
                 b"MspI" => ScoreTrackChunk::SeekAndPhraseInfo(data),
-                _ => return Err(nom::Err::Error(nom::error_position!(data, nom::error::ErrorKind::Switch))),
+                _ => ScoreTrackChunk::Unknown(tag, data),
             })
         })(data)
     }
@@ -469,8 +596,9 @@ pub struct ScoreTrack<'a> {
 
 fn parse_channel_status(format_type: FormatType, data: &[u8]) -> IResult<&[u8], Vec<ChannelStatus>> {
     Ok(match format_type {
-        FormatType::MobileStandardNoCompress => map(take(16usize), |x: &[u8]| x.iter().map(|&x| ChannelStatus::parse_mobile(x)).collect())(data)?,
+        FormatType::MobileStandardCompress | FormatType::MobileStandardNoCompress => {
+            map(take(16usize), |x: &[u8]| x.iter().map(|&x| ChannelStatus::parse_mobile(x)).collect())(data)?
+        }
         FormatType::HandyPhoneStandard => map(be_u16, ChannelStatus::parse_handy)(data)?,
-        _ => panic!("Unsupported format type {:?}", format_type),
     })
 }

--- a/smaf/src/lib.rs
+++ b/smaf/src/lib.rs
@@ -23,8 +23,8 @@ pub type Result<T> = result::Result<T, SmafError>;
 
 pub use self::{
     chunks::{
-        PCMAudioSequenceData, PCMAudioSequenceEvent, PCMAudioTrack, PCMAudioTrackChunk, PCMDataChunk, ScoreTrack, ScoreTrackChunk,
-        ScoreTrackSequenceEvent, SequenceData, WaveData,
+        parse_handy_variable_number, parse_variable_number, ChannelStatus, ChannelType, PCMAudioSequenceData, PCMAudioSequenceEvent, PCMAudioTrack,
+        PCMAudioTrackChunk, PCMDataChunk, ScoreTrack, ScoreTrackChunk, ScoreTrackSequenceEvent, SequenceData, WaveData,
     },
     constants::{BaseBit, Channel, FormatType, PcmWaveFormat, StreamWaveFormat},
     smaf::{Smaf, SmafChunk},

--- a/smaf/src/smaf.rs
+++ b/smaf/src/smaf.rs
@@ -11,15 +11,17 @@ use nom::{
 use nom_derive::{NomBE, Parse};
 
 use crate::{
-    chunks::{ContentsInfoChunk, OptionalDataChunk, PCMAudioTrack, ScoreTrack},
+    chunks::{ContentsInfoChunk, OptionalDataChunk, PCMAudioTrack, ScoreTrack, SequenceData},
     Result, SmafError,
 };
 
 pub enum SmafChunk<'a> {
-    ContentsInfo(ContentsInfoChunk<'a>),  // CNTI
-    OptionalData(OptionalDataChunk<'a>),  // OPDA
-    ScoreTrack(u8, ScoreTrack<'a>),       // MTRx
-    PCMAudioTrack(u8, PCMAudioTrack<'a>), // ATRx
+    ContentsInfo(ContentsInfoChunk<'a>),     // CNTI
+    OptionalData(OptionalDataChunk<'a>),     // OPDA
+    ScoreTrack(u8, ScoreTrack<'a>),          // MTRx
+    PCMAudioTrack(u8, PCMAudioTrack<'a>),    // ATRx
+    SoftbankSequenceData(Vec<SequenceData>), // SEQU
+    Unknown(&'a [u8], &'a [u8]),             // unrecognized chunk (tag, data)
 }
 
 impl<'a> Parse<&'a [u8]> for SmafChunk<'a> {
@@ -30,7 +32,8 @@ impl<'a> Parse<&'a [u8]> for SmafChunk<'a> {
                 b"OPDA" => Self::OptionalData(all_consuming(OptionalDataChunk::parse)(data)?.1),
                 &[b'M', b'T', b'R', x] => Self::ScoreTrack(x, all_consuming(ScoreTrack::parse)(data)?.1),
                 &[b'A', b'T', b'R', x] => Self::PCMAudioTrack(x, all_consuming(PCMAudioTrack::parse)(data)?.1),
-                _ => return Err(nom::Err::Error(nom::error_position!(data, nom::error::ErrorKind::Switch))),
+                b"SEQU" => Self::SoftbankSequenceData(all_consuming(SequenceData::parse_softbank)(data)?.1),
+                _ => Self::Unknown(tag, data),
             })
         })(data)
     }

--- a/smaf/tests/test.rs
+++ b/smaf/tests/test.rs
@@ -1,4 +1,7 @@
-use smaf::{BaseBit, Channel, FormatType, PCMAudioTrackChunk, PCMDataChunk, PcmWaveFormat, ScoreTrackChunk, Smaf, SmafChunk, StreamWaveFormat};
+use smaf::{
+    parse_handy_variable_number, parse_variable_number, BaseBit, Channel, FormatType, PCMAudioSequenceData, PCMAudioSequenceEvent,
+    PCMAudioTrackChunk, PCMDataChunk, PcmWaveFormat, ScoreTrackChunk, ScoreTrackSequenceEvent, SequenceData, Smaf, SmafChunk, StreamWaveFormat,
+};
 
 #[test]
 fn test_bell_load() -> anyhow::Result<()> {
@@ -92,4 +95,158 @@ fn test_midi_load() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[test]
+fn test_unknown_top_level_chunk_is_skipped() -> anyhow::Result<()> {
+    // Build a minimal MMMD file: CNTI chunk + unknown "XXXX" chunk
+    let mut data = Vec::new();
+    // MMMD magic
+    data.extend_from_slice(b"MMMD");
+    // Total length (excluding magic + length fields = 8 bytes): CNTI(13) + XXXX(12) + CRC(2) = 27
+    data.extend_from_slice(&27u32.to_be_bytes());
+    // CNTI chunk: tag + length(5) + data(5 bytes: 5 u8 fields, empty rest)
+    data.extend_from_slice(b"CNTI");
+    data.extend_from_slice(&5u32.to_be_bytes());
+    data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00]);
+    // Unknown chunk: tag + length(4) + data(4)
+    data.extend_from_slice(b"XXXX");
+    data.extend_from_slice(&4u32.to_be_bytes());
+    data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+    // CRC
+    data.extend_from_slice(&0u16.to_be_bytes());
+
+    let file = Smaf::parse(&data)?;
+
+    assert!(file.chunks.iter().any(|c| matches!(c, SmafChunk::ContentsInfo(_))));
+    assert!(file.chunks.iter().any(|c| matches!(c, SmafChunk::Unknown(b"XXXX", _))));
+
+    Ok(())
+}
+
+#[test]
+fn test_mobile_reserved_status_bytes_are_ignored() {
+    // duration=0, status=0xA5 (reserved), 2 data bytes, then 0xFF 0x2F 0x00 (end)
+    let seq = [0x00, 0xA5, 0x12, 0x34, 0x00, 0xFF, 0x2F, 0x00];
+    let (_, events) = SequenceData::parse_mobile(&seq).unwrap();
+
+    // The reserved 0xA5 should produce a Nop, and the stream should end cleanly
+    assert!(events.iter().all(|e| matches!(e.event, ScoreTrackSequenceEvent::Nop)));
+}
+
+#[test]
+fn test_handy_eos_with_short_data_does_not_panic() {
+    // Trailing data shorter than 4 bytes should not cause an out-of-bounds panic
+    let seq = [0x00, 0x01, 0x00];
+    let _ = SequenceData::parse_handy(&seq);
+}
+
+#[test]
+fn test_handy_variable_number_single_byte() {
+    let (_, val) = parse_handy_variable_number(&[0x42]).unwrap();
+    assert_eq!(val, 0x42);
+}
+
+#[test]
+fn test_handy_variable_number_two_byte() {
+    let (_, val) = parse_handy_variable_number(&[0x82, 0x34]).unwrap();
+    assert_eq!(val, ((0x02 + 1) << 7) | 0x34);
+}
+
+#[test]
+fn test_mobile_variable_number_single_byte_fast_path() {
+    let (_, val) = parse_variable_number(&[0x42]).unwrap();
+    assert_eq!(val, 0x42);
+}
+
+#[test]
+fn test_hps_short_pitch_bend() {
+    // duration=0, status=0x00, next_byte=0x13 (channel 0, event_type 0x13 = short pitch bend)
+    // then EoS
+    let seq = [0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x00, 0x00];
+    let (_, events) = SequenceData::parse_handy(&seq).unwrap();
+
+    assert!(events.iter().any(|e| matches!(
+        e.event,
+        ScoreTrackSequenceEvent::PitchBend { channel: 0, value: v } if v == ((0x13 - 0x10) * 16384 / 16)
+    )));
+}
+
+#[test]
+fn test_hps_short_expression() {
+    // duration=0, status=0x00, next_byte=0x05 (channel 0, event_type 0x05 = short expression)
+    // then EoS
+    let seq = [0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00];
+    let (_, events) = SequenceData::parse_handy(&seq).unwrap();
+
+    assert!(events
+        .iter()
+        .any(|e| matches!(e.event, ScoreTrackSequenceEvent::Expression { channel: 0, value: 0x37 })));
+}
+
+#[test]
+fn test_hps_note_has_no_velocity() {
+    // duration=0, status=0x49 (channel 1, octave 0, voice 9 = note 9), gate_time=0
+    // then EoS
+    let seq = [0x00, 0x49, 0x00, 0x00, 0x00, 0x00, 0x00];
+    let (_, events) = SequenceData::parse_handy(&seq).unwrap();
+
+    assert!(events.iter().any(|e| matches!(
+        e.event,
+        ScoreTrackSequenceEvent::NoteMessage {
+            channel: 1,
+            note: 9,
+            velocity: None,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn test_softbank_exclusive_uses_length_prefix() {
+    // duration=0, status=0xFF, next_byte=0xF0 (exclusive), length=3, data=[0x41,0x42,0x43]
+    // then EoS
+    let seq = [0x00, 0xFF, 0xF0, 0x03, 0x41, 0x42, 0x43, 0x00, 0x00, 0x00, 0x00];
+    let (_, events) = SequenceData::parse_softbank(&seq).unwrap();
+
+    assert!(events.iter().any(|e| matches!(
+        e.event,
+        ScoreTrackSequenceEvent::Exclusive(ref d) if d == &[0x41, 0x42, 0x43]
+    )));
+}
+
+#[test]
+fn test_hps_exclusive_uses_f7_terminator() {
+    // duration=0, status=0xFF, next_byte=0xF0 (exclusive), data until 0xF7
+    let seq = [0x00, 0xFF, 0xF0, 0x41, 0x42, 0xF7, 0x00, 0x00, 0x00, 0x00, 0x00];
+    let (_, events) = SequenceData::parse_handy(&seq).unwrap();
+
+    assert!(events.iter().any(|e| matches!(
+        e.event,
+        ScoreTrackSequenceEvent::Exclusive(ref d) if d == &[0x41, 0x42]
+    )));
+}
+
+#[test]
+fn test_pcm_short_expression() {
+    // duration=0, first_byte=0x00, second_byte=0x05 (channel 0, event_type 0x05 = short expression)
+    // then EoS
+    let seq = [0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00];
+    let (_, events) = PCMAudioSequenceData::parse(&seq).unwrap();
+
+    assert!(events
+        .iter()
+        .any(|e| matches!(e.event, PCMAudioSequenceEvent::Expression { channel: 0, value: 0x37 })));
+}
+
+#[test]
+fn test_pcm_short_pitch_bend() {
+    // duration=0, first_byte=0x00, second_byte=0x13 (channel 0, event_type 0x13 = short pitch bend)
+    // then EoS
+    let seq = [0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x00];
+    let (_, events) = PCMAudioSequenceData::parse(&seq).unwrap();
+
+    assert!(events
+        .iter()
+        .any(|e| matches!(e.event, PCMAudioSequenceEvent::PitchBend { channel: 0, value: 0x18 })));
 }

--- a/smaf_cli/src/main.rs
+++ b/smaf_cli/src/main.rs
@@ -1,7 +1,7 @@
 use core::time::Duration;
 use std::{env::args, fs};
 
-use midir::MidiOutput;
+use midir::{MidiOutput, MidiOutputConnection};
 use rodio::{buffer::SamplesBuffer, OutputStream, Sink};
 use tokio::time::sleep;
 
@@ -22,9 +22,15 @@ pub async fn main() {
 
     let events = parse_smaf(&data);
 
+    loop {
+        play_events(&events, &mut midi_out, &sink).await;
+    }
+}
+
+async fn play_events(events: &[(usize, SmafEvent)], midi_out: &mut MidiOutputConnection, sink: &Sink) {
     let mut now = 0;
     for (time, event) in events {
-        sleep(Duration::from_millis((time - now) as u64)).await;
+        sleep(Duration::from_millis(time.saturating_sub(now) as u64)).await;
 
         match event {
             SmafEvent::Wave {
@@ -32,24 +38,32 @@ pub async fn main() {
                 sampling_rate,
                 data,
             } => {
-                let buffer = SamplesBuffer::new(channel as _, sampling_rate as _, data);
+                let buffer = SamplesBuffer::new(*channel as _, *sampling_rate as _, data.clone());
                 sink.append(buffer);
             }
             SmafEvent::MidiNoteOn { channel, note, velocity } => {
-                midi_out.send(&[0x90 | channel, note, velocity]).unwrap();
+                midi_out.send(&[0x90 | *channel, *note, *velocity]).unwrap();
             }
             SmafEvent::MidiNoteOff { channel, note, velocity } => {
-                midi_out.send(&[0x80 | channel, note, velocity]).unwrap();
+                midi_out.send(&[0x80 | *channel, *note, *velocity]).unwrap();
             }
             SmafEvent::MidiProgramChange { channel, program } => {
-                midi_out.send(&[0xC0 | channel, program]).unwrap();
+                midi_out.send(&[0xC0 | *channel, *program]).unwrap();
             }
             SmafEvent::MidiControlChange { channel, control, value } => {
-                midi_out.send(&[0xB0 | channel, control, value]).unwrap();
+                midi_out.send(&[0xB0 | *channel, *control, *value]).unwrap();
+            }
+            SmafEvent::MidiPitchBend { channel, value } => {
+                midi_out
+                    .send(&[0xE0 | *channel, (*value & 0x7f) as u8, ((*value >> 7) & 0x7f) as u8])
+                    .unwrap();
+            }
+            SmafEvent::MidiSysEx(data) => {
+                midi_out.send(data).unwrap();
             }
             SmafEvent::End => {}
         }
 
-        now = time;
+        now = *time;
     }
 }

--- a/smaf_player/src/lib.rs
+++ b/smaf_player/src/lib.rs
@@ -5,8 +5,8 @@ use alloc::vec::Vec;
 mod adpcm;
 
 use smaf::{
-    Channel, PCMAudioSequenceEvent, PCMAudioTrack, PCMAudioTrackChunk, PCMDataChunk, ScoreTrack, ScoreTrackChunk, ScoreTrackSequenceEvent, Smaf,
-    SmafChunk,
+    Channel, ChannelStatus, ChannelType, PCMAudioSequenceEvent, PCMAudioTrack, PCMAudioTrackChunk, PCMDataChunk, ScoreTrack, ScoreTrackChunk,
+    ScoreTrackSequenceEvent, Smaf, SmafChunk,
 };
 
 use self::adpcm::decode_adpcm;
@@ -17,37 +17,144 @@ pub enum SmafEvent {
     MidiNoteOff { channel: u8, note: u8, velocity: u8 },
     MidiProgramChange { channel: u8, program: u8 },
     MidiControlChange { channel: u8, control: u8, value: u8 },
+    MidiPitchBend { channel: u8, value: u16 },
+    MidiSysEx(Vec<u8>),
     End,
 }
 
 pub fn parse_smaf(raw: &[u8]) -> Vec<(usize, SmafEvent)> {
-    let smaf = Smaf::parse(raw).unwrap();
+    let Ok(smaf) = Smaf::parse(raw) else {
+        return Vec::new();
+    };
 
-    let events = smaf.chunks.iter().filter_map(|x| match x {
-        SmafChunk::ScoreTrack(_, x) => Some(parse_score_track_events(x)),
-        SmafChunk::PCMAudioTrack(_, x) => Some(parse_pcm_audio_track_events(x)),
-        _ => None,
+    let mut result = Vec::new();
+    let mut handy_channel_offset = 0;
+    let mut handy_tone_map = ToneMap::new();
+
+    for chunk in &smaf.chunks {
+        match chunk {
+            SmafChunk::ScoreTrack(_, x) => {
+                let (events, next_offset) = parse_score_track_events(x, handy_channel_offset, &mut handy_tone_map);
+                result.extend(events);
+                handy_channel_offset = next_offset;
+            }
+            SmafChunk::PCMAudioTrack(_, x) => result.extend(parse_pcm_audio_track_events(x)),
+            SmafChunk::SoftbankSequenceData(x) => {
+                let mut tone_map = ToneMap::new();
+                tone_map.init_track(smaf::FormatType::HandyPhoneStandard, &[], handy_channel_offset);
+                let (events, next_offset) = parse_sequence_events(x, 20, 20, handy_channel_offset, true, &[], &mut tone_map);
+                result.extend(events);
+                handy_channel_offset = next_offset;
+            }
+            _ => {}
+        }
+    }
+
+    result.sort_by(|(left_time, left_event), (right_time, right_event)| {
+        left_time
+            .cmp(right_time)
+            .then_with(|| event_sort_key(left_event).cmp(&event_sort_key(right_event)))
     });
-
-    let mut result = events.flatten().collect::<Vec<_>>();
-    result.sort_by_key(|&(time, _)| time);
 
     result
 }
 
-fn parse_score_track_events(track: &ScoreTrack) -> Vec<(usize, SmafEvent)> {
-    let sequence_data = track
+fn event_sort_key(event: &SmafEvent) -> (u8, [u8; 3]) {
+    match event {
+        SmafEvent::MidiSysEx(data) => (4, [data.first().copied().unwrap_or(0xf0), 0, 0]),
+        SmafEvent::MidiControlChange { channel, control, value } => (5, [0xb0 | *channel, *control, *value]),
+        SmafEvent::MidiPitchBend { channel, value } => (5, [0xe0 | *channel, (value & 0x7f) as u8, ((value >> 7) & 0x7f) as u8]),
+        SmafEvent::MidiProgramChange { channel, program } => (6, [0xc0 | *channel, *program, 0]),
+        SmafEvent::MidiNoteOff { channel, note, velocity } => (20, [0x80 | *channel, *note, *velocity]),
+        SmafEvent::MidiNoteOn { channel, note, velocity } => (30, [0x90 | *channel, *note, *velocity]),
+        SmafEvent::Wave { channel, .. } => (40, [*channel, 0, 0]),
+        SmafEvent::End => (99, [0xff, 0x2f, 0]),
+    }
+}
+
+fn parse_score_track_events(track: &ScoreTrack, handy_channel_offset: u8, handy_tone_map: &mut ToneMap) -> (Vec<(usize, SmafEvent)>, u8) {
+    let mut result = Vec::new();
+    let mut mobile_tone_map = ToneMap::new();
+    let pcm_chunks = track
         .chunks
         .iter()
-        .find_map(|chunk| if let ScoreTrackChunk::SequenceData(x) = chunk { Some(x) } else { None })
-        .unwrap();
+        .find_map(|chunk| {
+            if let ScoreTrackChunk::PCMData(x) = chunk {
+                Some(x.as_slice())
+            } else {
+                None
+            }
+        })
+        .unwrap_or(&[]);
+    let is_handy = track.format_type == smaf::FormatType::HandyPhoneStandard;
 
+    if is_handy {
+        handy_tone_map.init_track(track.format_type, &track.channel_status, handy_channel_offset);
+    } else {
+        mobile_tone_map.init_track(track.format_type, &track.channel_status, 0);
+    }
+
+    for setup_data in track
+        .chunks
+        .iter()
+        .filter_map(|chunk| if let ScoreTrackChunk::SetupData(x) = chunk { Some(*x) } else { None })
+    {
+        result.extend(parse_setup_sysex_events(setup_data));
+    }
+
+    let tone_map: &mut ToneMap = if is_handy { handy_tone_map } else { &mut mobile_tone_map };
+
+    for sequence_data in track
+        .chunks
+        .iter()
+        .filter_map(|chunk| if let ScoreTrackChunk::SequenceData(x) = chunk { Some(x) } else { None })
+    {
+        tone_map.preclassify_sequence(sequence_data, is_handy, handy_channel_offset);
+        let (events, _) = parse_sequence_events(
+            sequence_data,
+            track.timebase_d,
+            track.timebase_g,
+            handy_channel_offset,
+            is_handy,
+            pcm_chunks,
+            &mut *tone_map,
+        );
+        result.extend(events);
+    }
+
+    let next_offset = if is_handy {
+        handy_channel_offset.saturating_add(4)
+    } else {
+        handy_channel_offset
+    };
+
+    (result, next_offset)
+}
+
+fn parse_sequence_events(
+    sequence_data: &[smaf::SequenceData],
+    timebase_d: u8,
+    timebase_g: u8,
+    channel_offset: u8,
+    use_channel_offset: bool,
+    pcm_chunks: &[PCMDataChunk<'_>],
+    tone_map: &mut ToneMap,
+) -> (Vec<(usize, SmafEvent)>, u8) {
     let mut result = Vec::new();
     let mut now = 0;
+    let mut octave_shift = [0i8; MAX_SMAF_CHANNELS];
+
+    let map_channel = |channel: u8| {
+        if use_channel_offset {
+            channel.saturating_add(channel_offset)
+        } else {
+            channel
+        }
+    };
 
     for event in sequence_data.iter() {
+        now += (event.duration * (timebase_d as u32)) as usize;
         let time = now;
-        now += (event.duration * (track.timebase_d as u32)) as usize;
 
         match event.event {
             ScoreTrackSequenceEvent::NoteMessage {
@@ -56,64 +163,725 @@ fn parse_score_track_events(track: &ScoreTrack) -> Vec<(usize, SmafEvent)> {
                 velocity,
                 gate_time,
             } => {
+                let channel = map_channel(channel);
                 // play wave on note 0??
                 if note == 0 {
-                    let pcm = track.chunks.iter().find_map(|x| {
-                        if let ScoreTrackChunk::PCMData(x) = x {
-                            for pcm_chunk in x {
-                                let PCMDataChunk::WaveData(x, y) = pcm_chunk;
-                                if *x == channel + 1 {
-                                    return Some(y);
-                                }
-                            }
+                    let pcm = pcm_chunks.iter().find_map(|pcm_chunk| {
+                        let PCMDataChunk::WaveData(x, y) = pcm_chunk;
+                        if *x == channel + 1 {
+                            Some(y)
+                        } else {
+                            None
                         }
-                        None
                     });
-                    if pcm.is_none() {
+                    let Some(pcm) = pcm else {
                         continue;
-                    }
-                    let pcm = pcm.unwrap();
-
-                    assert!(pcm.base_bit == smaf::BaseBit::Bit4); // current decoder is 4bit only
-                    assert!(pcm.channel == Channel::Mono); // current decoder is mono only
-
-                    let decoded = decode_adpcm(pcm.wave_data);
-                    let channel = match pcm.channel {
-                        Channel::Mono => 1,
-                        Channel::Stereo => 2,
                     };
+
+                    match pcm.format {
+                        smaf::StreamWaveFormat::YamahaADPCM => {
+                            if pcm.base_bit != smaf::BaseBit::Bit4 || pcm.channel != Channel::Mono {
+                                continue;
+                            }
+
+                            let decoded = decode_adpcm(pcm.wave_data);
+                            let channel = match pcm.channel {
+                                Channel::Mono => 1,
+                                Channel::Stereo => 2,
+                            };
+                            result.push((
+                                time,
+                                SmafEvent::Wave {
+                                    channel,
+                                    sampling_rate: pcm.sampling_freq as _,
+                                    data: decoded,
+                                },
+                            ))
+                        }
+                        smaf::StreamWaveFormat::TwosComplementPCM | smaf::StreamWaveFormat::OffsetBinaryPCM => {}
+                    }
+                } else {
+                    let duration = (gate_time * (timebase_g as u32)) as usize;
+                    let channel_index = (channel as usize).min(octave_shift.len() - 1);
+                    let shifted_note = tone_map.map_note(channel, note as i16 + (octave_shift[channel_index] as i16 * 12));
+                    let velocity = tone_map.note_velocity(channel, velocity);
+                    let midi_channel = tone_map.real_channel(channel);
+                    let duration = tone_map.note_duration(channel, duration);
                     result.push((
                         time,
-                        SmafEvent::Wave {
-                            channel,
-                            sampling_rate: pcm.sampling_freq as _,
-                            data: decoded,
+                        SmafEvent::MidiNoteOn {
+                            channel: midi_channel,
+                            note: shifted_note,
+                            velocity,
                         },
-                    ))
-                } else {
-                    let duration = (gate_time * (track.timebase_g as u32)) as usize;
-                    result.push((time, SmafEvent::MidiNoteOn { channel, note, velocity }));
-                    result.push((time + duration, SmafEvent::MidiNoteOff { channel, note, velocity }));
+                    ));
+                    result.push((
+                        time + duration,
+                        SmafEvent::MidiNoteOff {
+                            channel: midi_channel,
+                            note: shifted_note,
+                            velocity: 0,
+                        },
+                    ));
+                    result.extend(tone_map.emit_atmosphere_notes(time, duration, channel, shifted_note, velocity));
                 }
             }
             ScoreTrackSequenceEvent::ControlChange { channel, control, value } => {
+                let channel = map_channel(channel);
+                tone_map.update_control(channel, control, value);
+                let channel = tone_map.real_channel(channel);
                 result.push((time, SmafEvent::MidiControlChange { channel, control, value }))
             }
-            ScoreTrackSequenceEvent::ProgramChange { channel, program } => result.push((time, SmafEvent::MidiProgramChange { channel, program })),
-            ScoreTrackSequenceEvent::Exclusive(_) => continue,
+            ScoreTrackSequenceEvent::ProgramChange { channel, program } => {
+                let source_channel = map_channel(channel);
+                let (channel, mapped_program) = tone_map.set_program(source_channel, program);
+                result.push((
+                    time,
+                    SmafEvent::MidiProgramChange {
+                        channel,
+                        program: mapped_program,
+                    },
+                ));
+                result.extend(tone_map.emit_atmosphere_setup(time, source_channel, program));
+            }
+            ScoreTrackSequenceEvent::Exclusive(ref data) => {
+                result.push((time, SmafEvent::MidiSysEx(make_sysex_message(data))));
+            }
             ScoreTrackSequenceEvent::Nop => continue,
-            ScoreTrackSequenceEvent::PitchBend { .. } => continue,
-            ScoreTrackSequenceEvent::Volume { .. } => continue,
-            ScoreTrackSequenceEvent::Pan { .. } => continue,
-            ScoreTrackSequenceEvent::Expression { .. } => continue,
-            ScoreTrackSequenceEvent::OctaveShift { .. } => continue,
-            ScoreTrackSequenceEvent::Modulation { .. } => continue,
-            ScoreTrackSequenceEvent::BankSelect { .. } => continue,
+            ScoreTrackSequenceEvent::PitchBend { channel, value } => {
+                let channel = map_channel(channel);
+                let channel = tone_map.real_channel(channel);
+                result.push((
+                    time,
+                    SmafEvent::MidiPitchBend {
+                        channel,
+                        value: value.min(0x3fff),
+                    },
+                ));
+            }
+            ScoreTrackSequenceEvent::Volume { channel, value } => {
+                let channel = map_channel(channel);
+                tone_map.update_control(channel, 7, value);
+                if tone_map.format_type == smaf::FormatType::HandyPhoneStandard {
+                    if tone_map.is_rhythm(channel) {
+                        result.push((
+                            time,
+                            SmafEvent::MidiControlChange {
+                                channel: MIDI_DRUM_CHANNEL,
+                                control: 7,
+                                value: 100,
+                            },
+                        ));
+                    } else {
+                        let midi_channel = tone_map.real_channel(channel);
+                        let value = tone_map.effective_volume(channel);
+                        result.push((
+                            time,
+                            SmafEvent::MidiControlChange {
+                                channel: midi_channel,
+                                control: 7,
+                                value,
+                            },
+                        ));
+                    }
+                } else {
+                    let channel = tone_map.real_channel(channel);
+                    result.push((time, SmafEvent::MidiControlChange { channel, control: 7, value }));
+                }
+            }
+            ScoreTrackSequenceEvent::Pan { channel, value } => {
+                let channel = map_channel(channel);
+                let channel = tone_map.real_channel(channel);
+                result.push((time, SmafEvent::MidiControlChange { channel, control: 10, value }));
+            }
+            ScoreTrackSequenceEvent::Expression { channel, value } => {
+                let channel = map_channel(channel);
+                if tone_map.format_type == smaf::FormatType::HandyPhoneStandard {
+                    let value = tone_map.set_expression(channel, value);
+                    if !tone_map.is_rhythm(channel) {
+                        let channel = tone_map.real_channel(channel);
+                        result.push((time, SmafEvent::MidiControlChange { channel, control: 7, value }));
+                    }
+                } else {
+                    let channel = tone_map.real_channel(channel);
+                    result.push((time, SmafEvent::MidiControlChange { channel, control: 11, value }));
+                }
+            }
+            ScoreTrackSequenceEvent::OctaveShift { channel, value } => {
+                let channel = map_channel(channel);
+                if let Some(value) = parse_octave_shift(value) {
+                    let channel_index = (channel as usize).min(octave_shift.len() - 1);
+                    octave_shift[channel_index] = value;
+                }
+            }
+            ScoreTrackSequenceEvent::Modulation { channel, value } => {
+                let channel = map_channel(channel);
+                let channel = tone_map.real_channel(channel);
+                result.push((time, SmafEvent::MidiControlChange { channel, control: 1, value }));
+            }
+            ScoreTrackSequenceEvent::BankSelect { channel, value } => {
+                let channel = map_channel(channel);
+                tone_map.update_bank_select(channel, value);
+                let midi_channel = tone_map.real_channel(channel);
+                result.push((
+                    time,
+                    SmafEvent::MidiControlChange {
+                        channel: midi_channel,
+                        control: 0,
+                        value: value & 0x7f,
+                    },
+                ));
+            }
         }
     }
     result.push((now, SmafEvent::End));
 
+    let next_offset = if use_channel_offset {
+        channel_offset.saturating_add(4)
+    } else {
+        channel_offset
+    };
+
+    (result, next_offset)
+}
+
+const MIDI_DRUM_CHANNEL: u8 = 9;
+const MAX_SMAF_CHANNELS: usize = 64;
+const MELODY_ALLOCATION_ORDER: [u8; 15] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15];
+
+struct ToneMap {
+    format_type: smaf::FormatType,
+    channel_types: [u8; MAX_SMAF_CHANNELS],
+    programs: [u8; MAX_SMAF_CHANNELS],
+    channel_volumes: [u8; MAX_SMAF_CHANNELS],
+    expressions: [u8; MAX_SMAF_CHANNELS],
+    velocities: [u8; MAX_SMAF_CHANNELS],
+    bank_msb: [u8; MAX_SMAF_CHANNELS],
+    bank_lsb: [u8; MAX_SMAF_CHANNELS],
+    forced_rhythm: [bool; MAX_SMAF_CHANNELS],
+    real_map: [Option<u8>; MAX_SMAF_CHANNELS],
+    reserved_channels: [bool; 16],
+    atmosphere_source: [bool; MAX_SMAF_CHANNELS],
+    atmosphere_layers: [[Option<AtmosphereLayer>; 2]; MAX_SMAF_CHANNELS],
+}
+
+#[derive(Copy, Clone)]
+struct AtmosphereLayer {
+    channel: u8,
+    program: u8,
+    velocity_percent: u8,
+    note_offset: i8,
+    pan: u8,
+    pitch_bend: u16,
+    gate_extension_ms: usize,
+}
+
+impl ToneMap {
+    fn new() -> Self {
+        Self {
+            format_type: smaf::FormatType::MobileStandardNoCompress,
+            channel_types: [2; MAX_SMAF_CHANNELS],
+            programs: [0; MAX_SMAF_CHANNELS],
+            channel_volumes: [100; MAX_SMAF_CHANNELS],
+            expressions: [127; MAX_SMAF_CHANNELS],
+            velocities: [64; MAX_SMAF_CHANNELS],
+            bank_msb: [0; MAX_SMAF_CHANNELS],
+            bank_lsb: [0; MAX_SMAF_CHANNELS],
+            forced_rhythm: [false; MAX_SMAF_CHANNELS],
+            real_map: [None; MAX_SMAF_CHANNELS],
+            reserved_channels: [false; 16],
+            atmosphere_source: [false; MAX_SMAF_CHANNELS],
+            atmosphere_layers: [[None; 2]; MAX_SMAF_CHANNELS],
+        }
+    }
+
+    fn init_track(&mut self, format_type: smaf::FormatType, channel_statuses: &[ChannelStatus], channel_offset: u8) {
+        self.format_type = format_type;
+
+        if format_type == smaf::FormatType::HandyPhoneStandard {
+            let base = (channel_offset as usize).min(MAX_SMAF_CHANNELS - 4);
+            for local in 0..4 {
+                let channel = base + local;
+                self.channel_types[channel] = channel_statuses
+                    .get(local)
+                    .map(|status| match &status.channel_type {
+                        ChannelType::Rhythm => 3,
+                        _ => 1,
+                    })
+                    .unwrap_or(1);
+                self.programs[channel] = 0;
+                self.channel_volumes[channel] = 100;
+                self.expressions[channel] = 127;
+                self.velocities[channel] = 127;
+                self.bank_msb[channel] = 0;
+                self.bank_lsb[channel] = 0;
+                self.forced_rhythm[channel] = false;
+                self.atmosphere_source[channel] = false;
+                self.atmosphere_layers[channel] = [None; 2];
+            }
+            return;
+        }
+
+        self.channel_types = [2; MAX_SMAF_CHANNELS];
+        self.programs = [0; MAX_SMAF_CHANNELS];
+        self.channel_volumes = [100; MAX_SMAF_CHANNELS];
+        self.expressions = [127; MAX_SMAF_CHANNELS];
+        self.velocities = [64; MAX_SMAF_CHANNELS];
+        self.bank_msb = [0; MAX_SMAF_CHANNELS];
+        self.bank_lsb = [0; MAX_SMAF_CHANNELS];
+        self.forced_rhythm = [false; MAX_SMAF_CHANNELS];
+        self.real_map = [None; MAX_SMAF_CHANNELS];
+        self.reserved_channels = [false; 16];
+        self.atmosphere_source = [false; MAX_SMAF_CHANNELS];
+        self.atmosphere_layers = [[None; 2]; MAX_SMAF_CHANNELS];
+
+        for (channel, status) in channel_statuses.iter().take(16).enumerate() {
+            self.channel_types[channel] = match &status.channel_type {
+                ChannelType::NoCare | ChannelType::NoMelody => 2,
+                ChannelType::Melody => 1,
+                ChannelType::Rhythm => 3,
+            };
+        }
+    }
+
+    fn preclassify_sequence(&mut self, sequence_data: &[smaf::SequenceData], use_channel_offset: bool, channel_offset: u8) {
+        let mut bank_msb = self.bank_msb;
+
+        for event in sequence_data {
+            match event.event {
+                ScoreTrackSequenceEvent::ControlChange { channel, control, value } => {
+                    let channel = self.logical_channel(channel, use_channel_offset, channel_offset);
+                    if control == 0 {
+                        bank_msb[channel as usize] = value & 0x7f;
+                    }
+                }
+                ScoreTrackSequenceEvent::BankSelect { channel, value } => {
+                    let channel = self.logical_channel(channel, use_channel_offset, channel_offset);
+                    bank_msb[channel as usize] = value & 0x7f;
+                    if value & 0x80 != 0 {
+                        self.forced_rhythm[channel as usize] = true;
+                    }
+                }
+                ScoreTrackSequenceEvent::ProgramChange { channel, .. } => {
+                    let channel = self.logical_channel(channel, use_channel_offset, channel_offset);
+                    if bank_msb[channel as usize] == 0x7d {
+                        self.forced_rhythm[channel as usize] = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn logical_channel(&self, channel: u8, use_channel_offset: bool, channel_offset: u8) -> u8 {
+        if use_channel_offset {
+            channel.saturating_add(channel_offset).min((MAX_SMAF_CHANNELS - 1) as u8)
+        } else {
+            channel & 0x0f
+        }
+    }
+
+    fn pseudo_channel(&self, channel: u8) -> usize {
+        if self.format_type == smaf::FormatType::HandyPhoneStandard {
+            (channel as usize).min(MAX_SMAF_CHANNELS - 1)
+        } else {
+            (channel & 0x0f) as usize
+        }
+    }
+
+    fn is_rhythm(&self, channel: u8) -> bool {
+        let channel = self.pseudo_channel(channel);
+        self.channel_types[channel] == 3 || self.forced_rhythm[channel] || self.bank_msb[channel] == 0x7d
+    }
+
+    fn real_channel(&mut self, channel: u8) -> u8 {
+        let channel = self.pseudo_channel(channel);
+        if self.is_rhythm(channel as u8) {
+            return MIDI_DRUM_CHANNEL;
+        }
+
+        if let Some(real_channel) = self.real_map[channel] {
+            return real_channel;
+        }
+
+        let mut used = [false; 16];
+        used[MIDI_DRUM_CHANNEL as usize] = true;
+        for real_channel in self.real_map.iter().flatten() {
+            used[*real_channel as usize] = true;
+        }
+        for (channel, reserved) in self.reserved_channels.iter().enumerate() {
+            used[channel] |= *reserved;
+        }
+
+        let real_channel = MELODY_ALLOCATION_ORDER
+            .iter()
+            .copied()
+            .find(|candidate| !used[*candidate as usize])
+            .unwrap_or(channel as u8);
+        self.real_map[channel] = Some(real_channel);
+        real_channel
+    }
+
+    fn update_control(&mut self, channel: u8, control: u8, value: u8) {
+        let channel = self.pseudo_channel(channel);
+        match control {
+            0 => self.bank_msb[channel] = value & 0x7f,
+            32 => self.bank_lsb[channel] = value & 0x7f,
+            7 => self.channel_volumes[channel] = value.min(0x7f),
+            _ => {}
+        }
+    }
+
+    fn update_bank_select(&mut self, channel: u8, value: u8) {
+        let channel = self.pseudo_channel(channel);
+        if value & 0x80 != 0 {
+            self.forced_rhythm[channel] = true;
+        }
+        self.bank_msb[channel] = value & 0x7f;
+    }
+
+    fn set_program(&mut self, channel: u8, program: u8) -> (u8, u8) {
+        let channel = self.pseudo_channel(channel);
+        if self.format_type == smaf::FormatType::HandyPhoneStandard && self.channel_types[channel] == 3 {
+            self.programs[channel] = program.min(0x7f);
+            return (MIDI_DRUM_CHANNEL, 0);
+        }
+
+        if self.bank_msb[channel] == 0x7d {
+            self.forced_rhythm[channel] = true;
+        }
+
+        let program = if self.is_rhythm(channel as u8) {
+            0
+        } else {
+            self.map_program(channel as u8, program)
+        };
+        self.programs[channel] = program;
+
+        (self.real_channel(channel as u8), program)
+    }
+
+    fn map_program(&self, channel: u8, program: u8) -> u8 {
+        let channel = self.pseudo_channel(channel);
+        match (self.bank_msb[channel], self.bank_lsb[channel], program & 0x7f) {
+            (0x7c, 0x01, 0x22) => 81,
+            (0x7c, 0x01, 0x70) => 30,
+            (0x7c, 0x01, 0x46) => 84,
+            (0x7c, 0x01, 0x21) => 33,
+            (0x7c, 0x01, 0x6a) => 87,
+            (0x7c, 0x01, 0x62) => 98,
+            (0x7d, 0x00, 0x02) => 0,
+            _ => program & 0x7f,
+        }
+    }
+
+    fn map_note(&self, channel: u8, note: i16) -> u8 {
+        let channel_index = self.pseudo_channel(channel);
+
+        if self.format_type == smaf::FormatType::HandyPhoneStandard {
+            if self.is_rhythm(channel) {
+                return self.programs[channel_index].min(0x7f);
+            }
+            return (note + 36).clamp(0, 127) as u8;
+        }
+
+        let note = note.clamp(0, 127) as u8;
+        if !self.is_rhythm(channel) {
+            return note;
+        }
+
+        match note {
+            0x12 => 45,
+            0x1a => 41,
+            0x1f => 47,
+            0x4d => 50,
+            0x54 => 43,
+            0x59 => 48,
+            _ => note,
+        }
+    }
+
+    fn note_velocity(&mut self, channel: u8, velocity: Option<u8>) -> u8 {
+        let channel = self.pseudo_channel(channel);
+        if self.format_type == smaf::FormatType::HandyPhoneStandard && self.channel_types[channel] == 3 {
+            return self.hps_drum_velocity(channel);
+        }
+        if let Some(velocity) = velocity {
+            let velocity = velocity.min(0x7f);
+            self.velocities[channel] = velocity;
+            velocity
+        } else {
+            self.velocities[channel]
+        }
+    }
+
+    fn hps_drum_velocity(&self, channel: usize) -> u8 {
+        let value = if self.expressions[channel] < 64 {
+            (self.channel_volumes[channel] as u16 * self.expressions[channel] as u16) / 102
+        } else {
+            (self.channel_volumes[channel] as u16 * self.expressions[channel] as u16) / 100
+        };
+
+        value.clamp(1, 127) as u8
+    }
+
+    fn set_expression(&mut self, channel: u8, value: u8) -> u8 {
+        let channel = self.pseudo_channel(channel);
+        self.expressions[channel] = value.min(0x7f);
+        ((self.channel_volumes[channel] as u16 * self.expressions[channel] as u16) / 127).min(127) as u8
+    }
+
+    fn effective_volume(&self, channel: u8) -> u8 {
+        let channel = self.pseudo_channel(channel);
+        ((self.channel_volumes[channel] as u16 * self.expressions[channel] as u16) / 127).min(127) as u8
+    }
+
+    fn note_duration(&self, channel: u8, duration: usize) -> usize {
+        if self.atmosphere_source[self.pseudo_channel(channel)] {
+            duration + 120
+        } else {
+            duration
+        }
+    }
+
+    fn emit_atmosphere_setup(&mut self, time: usize, channel: u8, program: u8) -> Vec<(usize, SmafEvent)> {
+        if !self.is_atmosphere_voice(channel, program) {
+            return Vec::new();
+        }
+
+        let channel_index = self.pseudo_channel(channel);
+        self.atmosphere_source[channel_index] = true;
+
+        if self.atmosphere_layers[channel_index][0].is_none() {
+            let specs = [
+                AtmosphereLayer {
+                    channel: 15,
+                    program: 99,
+                    velocity_percent: 42,
+                    note_offset: 0,
+                    pan: 52,
+                    pitch_bend: 8192 - 170,
+                    gate_extension_ms: 220,
+                },
+                AtmosphereLayer {
+                    channel: 14,
+                    program: 94,
+                    velocity_percent: 30,
+                    note_offset: -12,
+                    pan: 76,
+                    pitch_bend: 8192 + 130,
+                    gate_extension_ms: 360,
+                },
+            ];
+
+            let mut next_layer = 0;
+            let mut used = [false; 16];
+            used[MIDI_DRUM_CHANNEL as usize] = true;
+            for real_channel in self.real_map.iter().flatten() {
+                used[*real_channel as usize] = true;
+            }
+            for (reserved_channel, reserved) in self.reserved_channels.iter().enumerate() {
+                used[reserved_channel] |= *reserved;
+            }
+
+            for spec in specs {
+                if !used[spec.channel as usize] && next_layer < self.atmosphere_layers[channel_index].len() {
+                    self.reserved_channels[spec.channel as usize] = true;
+                    self.atmosphere_layers[channel_index][next_layer] = Some(spec);
+                    next_layer += 1;
+                }
+            }
+        }
+
+        let mut result = Vec::new();
+        let source_real_channel = self.real_channel(channel);
+        result.push((
+            time,
+            SmafEvent::MidiControlChange {
+                channel: source_real_channel,
+                control: 91,
+                value: 92,
+            },
+        ));
+        result.push((
+            time,
+            SmafEvent::MidiControlChange {
+                channel: source_real_channel,
+                control: 93,
+                value: 76,
+            },
+        ));
+        result.push((
+            time,
+            SmafEvent::MidiControlChange {
+                channel: source_real_channel,
+                control: 72,
+                value: 18,
+            },
+        ));
+
+        let source_volume = ((self.channel_volumes[channel_index] as u16 * 70) / 100).clamp(1, 127) as u8;
+        for layer in self.atmosphere_layers[channel_index].iter().flatten() {
+            result.push((
+                time,
+                SmafEvent::MidiControlChange {
+                    channel: layer.channel,
+                    control: 7,
+                    value: source_volume,
+                },
+            ));
+            result.push((
+                time,
+                SmafEvent::MidiControlChange {
+                    channel: layer.channel,
+                    control: 10,
+                    value: layer.pan,
+                },
+            ));
+            result.push((
+                time,
+                SmafEvent::MidiControlChange {
+                    channel: layer.channel,
+                    control: 11,
+                    value: 110,
+                },
+            ));
+            result.push((
+                time,
+                SmafEvent::MidiControlChange {
+                    channel: layer.channel,
+                    control: 91,
+                    value: 104,
+                },
+            ));
+            result.push((
+                time,
+                SmafEvent::MidiControlChange {
+                    channel: layer.channel,
+                    control: 93,
+                    value: 84,
+                },
+            ));
+            result.push((
+                time,
+                SmafEvent::MidiControlChange {
+                    channel: layer.channel,
+                    control: 72,
+                    value: 22,
+                },
+            ));
+            result.push((
+                time,
+                SmafEvent::MidiProgramChange {
+                    channel: layer.channel,
+                    program: layer.program,
+                },
+            ));
+            result.push((
+                time,
+                SmafEvent::MidiPitchBend {
+                    channel: layer.channel,
+                    value: layer.pitch_bend,
+                },
+            ));
+        }
+
+        result
+    }
+
+    fn emit_atmosphere_notes(&self, time: usize, duration: usize, channel: u8, note: u8, velocity: u8) -> Vec<(usize, SmafEvent)> {
+        let channel = self.pseudo_channel(channel);
+        if !self.atmosphere_source[channel] {
+            return Vec::new();
+        }
+
+        let mut result = Vec::new();
+        for layer in self.atmosphere_layers[channel].iter().flatten() {
+            let note = (note as i16 + layer.note_offset as i16).clamp(0, 127) as u8;
+            let velocity = ((velocity as u16 * layer.velocity_percent as u16) / 100).clamp(1, 127) as u8;
+            result.push((
+                time,
+                SmafEvent::MidiNoteOn {
+                    channel: layer.channel,
+                    note,
+                    velocity,
+                },
+            ));
+            result.push((
+                time + duration + layer.gate_extension_ms,
+                SmafEvent::MidiNoteOff {
+                    channel: layer.channel,
+                    note,
+                    velocity: 0,
+                },
+            ));
+        }
+
+        result
+    }
+
+    fn is_atmosphere_voice(&self, channel: u8, program: u8) -> bool {
+        let channel = self.pseudo_channel(channel);
+        (self.bank_msb[channel], self.bank_lsb[channel], program & 0x7f) == (0x7c, 0x01, 0x62)
+    }
+}
+
+fn parse_setup_sysex_events(data: &[u8]) -> Vec<(usize, SmafEvent)> {
+    let mut result = Vec::new();
+    let mut offset = 0;
+
+    while offset < data.len() {
+        if data[offset] != 0xf0 {
+            break;
+        }
+        offset += 1;
+
+        let Some((length, next_offset)) = read_midi_vlq(data, offset) else {
+            break;
+        };
+        offset = next_offset;
+
+        if offset + length > data.len() {
+            break;
+        }
+
+        result.push((0, SmafEvent::MidiSysEx(make_sysex_message(&data[offset..offset + length]))));
+        offset += length;
+    }
+
     result
+}
+
+fn read_midi_vlq(data: &[u8], mut offset: usize) -> Option<(usize, usize)> {
+    let mut value = 0usize;
+    loop {
+        let byte = *data.get(offset)?;
+        offset += 1;
+        value = (value << 7) | ((byte & 0x7f) as usize);
+        if byte & 0x80 == 0 {
+            return Some((value, offset));
+        }
+    }
+}
+
+fn make_sysex_message(data: &[u8]) -> Vec<u8> {
+    let mut message = Vec::with_capacity(data.len() + 2);
+    if data.first().copied() != Some(0xf0) {
+        message.push(0xf0);
+    }
+    message.extend_from_slice(data);
+    if message.last().copied() != Some(0xf7) {
+        message.push(0xf7);
+    }
+    message
+}
+
+fn parse_octave_shift(value: u8) -> Option<i8> {
+    match value {
+        0x00..=0x04 => Some(value as i8),
+        0x81..=0x84 => Some(-((value - 0x80) as i8)),
+        _ => None,
+    }
 }
 
 fn parse_pcm_audio_track_events(track: &PCMAudioTrack) -> Vec<(usize, SmafEvent)> {
@@ -133,8 +901,8 @@ fn parse_pcm_audio_track_events(track: &PCMAudioTrack) -> Vec<(usize, SmafEvent)
     let mut now = 0;
 
     for event in sequence_data.iter() {
-        let time = now;
         now += (event.duration * (track.timebase_d as u32)) as usize;
+        let time = now;
 
         match event.event {
             PCMAudioSequenceEvent::WaveMessage {
@@ -183,4 +951,293 @@ fn parse_pcm_audio_track_events(track: &PCMAudioTrack) -> Vec<(usize, SmafEvent)
 
     result.push((now, SmafEvent::End));
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::{parse_pcm_audio_track_events, parse_sequence_events, SmafEvent, ToneMap};
+    use smaf::{
+        BaseBit, Channel, ChannelStatus, ChannelType, PCMAudioSequenceData, PCMAudioSequenceEvent, PCMAudioTrack, PCMAudioTrackChunk, PcmWaveFormat,
+        ScoreTrackSequenceEvent, SequenceData,
+    };
+
+    fn channel_status(channel_type: ChannelType) -> ChannelStatus {
+        ChannelStatus {
+            kcs: 0,
+            vs: 0,
+            led: 0,
+            channel_type,
+        }
+    }
+
+    #[test]
+    fn maps_yamaha_ma_program_to_gm_fallback() {
+        let mut tone_map = ToneMap::new();
+
+        tone_map.update_control(1, 0, 0x7c);
+        tone_map.update_control(1, 32, 0x01);
+
+        assert_eq!(tone_map.set_program(1, 0x22), (0, 81));
+    }
+
+    #[test]
+    fn maps_yamaha_rhythm_bank_to_midi_drum_channel() {
+        let mut tone_map = ToneMap::new();
+
+        tone_map.update_control(9, 0, 0x7d);
+        tone_map.update_control(9, 32, 0x00);
+
+        assert_eq!(tone_map.set_program(9, 0x02), (9, 0));
+        assert_eq!(tone_map.map_note(9, 0x1a), 41);
+    }
+
+    #[test]
+    fn compacts_melody_channels_around_midi_drum_channel() {
+        let mut tone_map = ToneMap::new();
+
+        assert_eq!(tone_map.real_channel(1), 0);
+        assert_eq!(tone_map.real_channel(2), 1);
+        assert_eq!(tone_map.real_channel(9), 2);
+
+        tone_map.update_control(10, 0, 0x7d);
+        assert_eq!(tone_map.real_channel(10), 9);
+
+        assert_eq!(tone_map.real_channel(11), 3);
+    }
+
+    #[test]
+    fn emits_atmosphere_layers_for_yamaha_ma_ambience_voice() {
+        let mut tone_map = ToneMap::new();
+
+        tone_map.update_control(7, 0, 0x7c);
+        tone_map.update_control(7, 32, 0x01);
+        tone_map.update_control(7, 7, 80);
+
+        let setup = tone_map.emit_atmosphere_setup(0, 7, 0x62);
+        assert!(setup
+            .iter()
+            .any(|(_, event)| matches!(event, SmafEvent::MidiProgramChange { channel: 15, program: 99 })));
+        assert!(setup.iter().any(|(_, event)| matches!(
+            event,
+            SmafEvent::MidiControlChange {
+                channel: 0,
+                control: 91,
+                value: 92
+            }
+        )));
+        assert!(setup.iter().any(|(_, event)| matches!(
+            event,
+            SmafEvent::MidiControlChange {
+                channel: 15,
+                control: 7,
+                value: 56
+            }
+        )));
+        assert!(setup.iter().any(|(_, event)| matches!(
+            event,
+            SmafEvent::MidiControlChange {
+                channel: 15,
+                control: 72,
+                value: 22
+            }
+        )));
+
+        let notes = tone_map.emit_atmosphere_notes(100, 200, 7, 84, 64);
+        assert!(notes
+            .iter()
+            .any(|(_, event)| matches!(event, SmafEvent::MidiNoteOn { channel: 15, note: 84, .. })));
+    }
+
+    #[test]
+    fn reuses_previous_velocity_for_mobile_notes_without_velocity() {
+        let mut tone_map = ToneMap::new();
+        tone_map.init_track(smaf::FormatType::MobileStandardNoCompress, &[], 0);
+        let sequence = [
+            SequenceData {
+                duration: 0,
+                event: ScoreTrackSequenceEvent::NoteMessage {
+                    channel: 0,
+                    note: 60,
+                    velocity: Some(96),
+                    gate_time: 10,
+                },
+            },
+            SequenceData {
+                duration: 0,
+                event: ScoreTrackSequenceEvent::NoteMessage {
+                    channel: 0,
+                    note: 62,
+                    velocity: None,
+                    gate_time: 10,
+                },
+            },
+        ];
+
+        let (events, _) = parse_sequence_events(&sequence, 1, 1, 0, false, &[], &mut tone_map);
+        assert!(events
+            .iter()
+            .any(|(_, event)| matches!(event, SmafEvent::MidiNoteOn { note: 62, velocity: 96, .. })));
+    }
+
+    #[test]
+    fn applies_sequence_duration_before_event() {
+        let mut tone_map = ToneMap::new();
+        tone_map.init_track(smaf::FormatType::MobileStandardNoCompress, &[], 0);
+        let sequence = [SequenceData {
+            duration: 5,
+            event: ScoreTrackSequenceEvent::NoteMessage {
+                channel: 0,
+                note: 60,
+                velocity: Some(64),
+                gate_time: 2,
+            },
+        }];
+
+        let (events, _) = parse_sequence_events(&sequence, 4, 4, 0, false, &[], &mut tone_map);
+        assert!(events
+            .iter()
+            .any(|(time, event)| *time == 20 && matches!(event, SmafEvent::MidiNoteOn { note: 60, .. })));
+        assert!(events
+            .iter()
+            .any(|(time, event)| *time == 28 && matches!(event, SmafEvent::MidiNoteOff { note: 60, .. })));
+    }
+
+    #[test]
+    fn applies_pcm_sequence_duration_before_event() {
+        let track = PCMAudioTrack {
+            format_type: 0,
+            sequence_type: 0,
+            channel: Channel::Mono,
+            format: PcmWaveFormat::Adpcm,
+            sampling_freq: 8000,
+            base_bit: BaseBit::Bit4,
+            timebase_d: 4,
+            timebase_g: 4,
+            chunks: vec![PCMAudioTrackChunk::SequenceData(vec![PCMAudioSequenceData {
+                duration: 5,
+                event: PCMAudioSequenceEvent::Nop,
+            }])],
+        };
+
+        let events = parse_pcm_audio_track_events(&track);
+        assert!(events.iter().any(|(time, event)| *time == 20 && matches!(event, SmafEvent::End)));
+    }
+
+    #[test]
+    fn hps_tracks_keep_independent_midi_channel_allocations() {
+        let mut tone_map = ToneMap::new();
+        let first_track = [channel_status(ChannelType::Melody)];
+        tone_map.init_track(smaf::FormatType::HandyPhoneStandard, &first_track, 0);
+        let first_sequence = [SequenceData {
+            duration: 0,
+            event: ScoreTrackSequenceEvent::ProgramChange { channel: 0, program: 40 },
+        }];
+
+        let (events, _) = parse_sequence_events(&first_sequence, 1, 1, 0, true, &[], &mut tone_map);
+        assert!(events
+            .iter()
+            .any(|(_, event)| matches!(event, SmafEvent::MidiProgramChange { channel: 0, program: 40 })));
+
+        let second_track = [channel_status(ChannelType::Melody)];
+        tone_map.init_track(smaf::FormatType::HandyPhoneStandard, &second_track, 4);
+        let second_sequence = [SequenceData {
+            duration: 0,
+            event: ScoreTrackSequenceEvent::ProgramChange { channel: 0, program: 41 },
+        }];
+
+        let (events, _) = parse_sequence_events(&second_sequence, 1, 1, 4, true, &[], &mut tone_map);
+        assert!(events
+            .iter()
+            .any(|(_, event)| matches!(event, SmafEvent::MidiProgramChange { channel: 1, program: 41 })));
+    }
+
+    #[test]
+    fn hps_rhythm_uses_program_as_drum_key_and_expression_velocity() {
+        let mut tone_map = ToneMap::new();
+        let statuses = [channel_status(ChannelType::Rhythm)];
+        tone_map.init_track(smaf::FormatType::HandyPhoneStandard, &statuses, 0);
+        let sequence = [
+            SequenceData {
+                duration: 0,
+                event: ScoreTrackSequenceEvent::ProgramChange { channel: 0, program: 35 },
+            },
+            SequenceData {
+                duration: 0,
+                event: ScoreTrackSequenceEvent::Expression { channel: 0, value: 92 },
+            },
+            SequenceData {
+                duration: 0,
+                event: ScoreTrackSequenceEvent::NoteMessage {
+                    channel: 0,
+                    note: 1,
+                    velocity: None,
+                    gate_time: 10,
+                },
+            },
+        ];
+
+        let (events, _) = parse_sequence_events(&sequence, 1, 1, 0, true, &[], &mut tone_map);
+        assert!(events
+            .iter()
+            .any(|(_, event)| matches!(event, SmafEvent::MidiProgramChange { channel: 9, program: 0 })));
+        assert!(events.iter().any(|(_, event)| {
+            matches!(
+                event,
+                SmafEvent::MidiNoteOn {
+                    channel: 9,
+                    note: 35,
+                    velocity: 92
+                }
+            )
+        }));
+        assert!(!events
+            .iter()
+            .any(|(_, event)| matches!(event, SmafEvent::MidiControlChange { channel: 9, control: 11, .. })));
+    }
+
+    #[test]
+    fn hps_melody_expression_is_folded_into_volume() {
+        let mut tone_map = ToneMap::new();
+        let statuses = [channel_status(ChannelType::Melody)];
+        tone_map.init_track(smaf::FormatType::HandyPhoneStandard, &statuses, 0);
+        let sequence = [
+            SequenceData {
+                duration: 0,
+                event: ScoreTrackSequenceEvent::Volume { channel: 0, value: 100 },
+            },
+            SequenceData {
+                duration: 0,
+                event: ScoreTrackSequenceEvent::Expression { channel: 0, value: 92 },
+            },
+        ];
+
+        let (events, _) = parse_sequence_events(&sequence, 1, 1, 0, true, &[], &mut tone_map);
+        assert!(events.iter().any(|(_, event)| matches!(
+            event,
+            SmafEvent::MidiControlChange {
+                channel: 0,
+                control: 7,
+                value: 72
+            }
+        )));
+        assert!(!events
+            .iter()
+            .any(|(_, event)| matches!(event, SmafEvent::MidiControlChange { channel: 0, control: 11, .. })));
+    }
+
+    #[test]
+    fn hps_melody_pitch_adds_base_offset_but_rhythm_does_not() {
+        let mut melody_map = ToneMap::new();
+        let melody = [channel_status(ChannelType::Melody)];
+        melody_map.init_track(smaf::FormatType::HandyPhoneStandard, &melody, 0);
+        assert_eq!(melody_map.map_note(0, 24), 60);
+
+        let mut rhythm_map = ToneMap::new();
+        let rhythm = [channel_status(ChannelType::Rhythm)];
+        rhythm_map.init_track(smaf::FormatType::HandyPhoneStandard, &rhythm, 0);
+        assert_eq!(rhythm_map.set_program(0, 38), (9, 0));
+        assert_eq!(rhythm_map.map_note(0, 24), 38);
+    }
 }


### PR DESCRIPTION
- **HPS/Mobile/Softbank tri-format full support**: Unified parse_handy_like entry point, Softbank sequence data parsing, Mobile compressed format Huffman decoding
- **Yamaha MA tone library mapping**: ToneMap manages channel mapping, program change, and atmosphere layer synthesis
- **MIDI event extensions**: Pitch bend, SysEx parsing and playback
- **MIDI channel auto-assignment**: Automatically assigns channels per track to avoid conflicts
- **Loop playback**: The repeat parameter is passed through from the WIPI C/Java API all the way to the backend SmafPlayer, supporting infinite looping
- **Full test coverage**: Parser format tests, PCM short format lookup table tests, and backend repeat regression tests

Some feat require modifications on the Main Emulator side and will be submitted as a PR later. : )

Test Video:

https://github.com/user-attachments/assets/d82ff5fb-11d4-4b80-a45c-42be1eeac4ad

